### PR TITLE
TypeScript generated schemes use schema casing for interfaces but not…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGE LOG
 
+## 1.2.7
+
+- typegen interfaces are now cased according to schema, but sql props
+remain lowercase, better usability
+
 ## 1.2.6
 
 - typegen schema name output is now all lowercase

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ch1/sql-tables",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "Thin data access layer and schema generator for Postgres (and potentially other SQLs) that leverages RxJS streams and can generate TypeScript type defintions",
   "bin": "./sql-tables.js",
   "main": "index.js",

--- a/src/schema/schema-to-typescript.ts
+++ b/src/schema/schema-to-typescript.ts
@@ -17,7 +17,7 @@ export function schemaStructPropToTypeScript(
 export function scPropToInterface(
   state: string, scProp: SchemaPropStrict, name: string
 ): string {
-  return state + `export interface ${name.toLowerCase()} {
+  return state + `export interface ${name} {
 ${objReduce(scProp.struct, schemaStructPropToTypeScript, '')}}
 
 `;
@@ -29,7 +29,7 @@ export function schemaToTypeScript(schema: SchemaStrict): string {
 
 export function dbInterfaceFromSchema(schema: SchemaStrict) {
   return objReduce(schema, (state: string, prop, name: string) => {
-    state += `  ${name.toLowerCase()}: ${name.toLowerCase()};\n`;
+    state += `  ${name.toLowerCase()}: ${name};\n`;
     return state;
   }, 'export interface DbSchema {\n') + '}';
 }


### PR DESCRIPTION
… prop names